### PR TITLE
Remove csp meta tag

### DIFF
--- a/app/views/layouts/rake_ui/application.html.erb
+++ b/app/views/layouts/rake_ui/application.html.erb
@@ -3,7 +3,6 @@
 <head>
   <title>Rake ui</title>
   <%= csrf_meta_tags %>
-  <%= csp_meta_tag %>
 
   <link rel="stylesheet" href="https://cdn.rawgit.com/doximity/vital/v2.2.1/dist/css/vital.min.css">
 </head>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -4,7 +4,6 @@
     <title>Dummy</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
   </head>


### PR DESCRIPTION
What?
- Remove csp meta tag from application file

Why?
- Causing csrf/cors issues since our (MIT) rails version is alder than rails 5.2, csp_meta_tag is not available in that rals version

Testing scope:
- [ ] Integrate rake-ui in MIT and run it and check `BASE_URL/rake_tasks` and it should load rake ui properly
